### PR TITLE
Use enum instead of integer to control states

### DIFF
--- a/web/src/components/Exchange/index.js
+++ b/web/src/components/Exchange/index.js
@@ -102,7 +102,6 @@ const CouponRow = ({code, changedAt, couponsType}) => {
   )
 }
 
-
 const CouponPage = ({ setPage }) => {
   const [coupons, setCoupons] = useState([]);
   useEffect(()=>{
@@ -120,7 +119,7 @@ const CouponPage = ({ setPage }) => {
     });
   },[]);
 
-  const handleCancel = () => setPage(0);
+  const handleCancel = () => setPage(PointExchange.BriefInfo);
   return (
     <Content>
       <Title>{langText("COUPON_YOUR_COUPON")}</Title>
@@ -208,12 +207,18 @@ const Coupon = ({ name, points, setTargetCoupon }) => {
   )
 }
 
+const ExchangeSteps = Object.freeze({
+  'CouponList': 0,
+  'ConfirmExchange': 1,
+  'Success': 2,
+});
+
 const ExchangePage = ({ points, setPage }) => {
   const [token, setToken] = useState();
   const [user, setUser] = useContext(UserContext);
-  const [step, setStep] = useState(0);
-  const handleBack = () => setStep(0);
-  const handleCancel = () => setPage(0);
+  const [step, setStep] = useState(ExchangeSteps.CouponList);
+  const handleBack = () => setStep(ExchangeSteps.CouponList);
+  const handleCancel = () => setPage(PointExchange.BriefInfo);
   const [targetCoupon, setTargetCoupon] = useState(null);
   const [couponList, setCouponList] = useState([]);
   const handleExchange = (remainingPoints) => {
@@ -230,7 +235,7 @@ const ExchangePage = ({ points, setPage }) => {
         const { state, data: {message} } = error.response;
         console.error('exchange Coupons error: ', message);
     });
-    setStep(2);
+    setStep(ExchangeSteps.Success);
   };
 
   useEffect(() => {
@@ -249,11 +254,11 @@ const ExchangePage = ({ points, setPage }) => {
 
   useEffect(() => {
     if (targetCoupon === null) return;
-    setStep(1);
+    setStep(ExchangeSteps.ConfirmExchange);
   }, [targetCoupon])
   return (
     <>
-      {step === 0 ?
+      {step === ExchangeSteps.CouponList ?
         <Content>
           <Title>{langText("COUPON_EXCH_ITEM")}</Title>
           <List>
@@ -261,7 +266,7 @@ const ExchangePage = ({ points, setPage }) => {
           </List>
           <Cancel onClick={handleCancel}>{langText("BACK")}</Cancel>
         </Content> : null}
-      {step === 1 ?
+      {step === ExchangeSteps.ConfirmExchange ?
         <Content>
           <Title>{langText("COUPON_CONFIRM_EXCH")}</Title>
           {ReactHtmlParser(langText("COUPON_USING_POINTS")
@@ -271,7 +276,7 @@ const ExchangePage = ({ points, setPage }) => {
           <Cancel onClick={handleBack}>{langText("CANCEL")}</Cancel>
           <Button onClick={() => handleExchange((points - targetCoupon.points))}>{langText("CONFIRM")}</Button>
         </Content> : null}
-      {step === 2 ?
+      {step === ExchangeSteps.Success ?
         <Content>
           <Title>{langText("COUPON_EXCH_DONE")}</Title>
           <div>{langText("COUPON_DONE_NOTICE")}</div>
@@ -281,12 +286,18 @@ const ExchangePage = ({ points, setPage }) => {
   )
 }
 
+const PointExchange = Object.freeze({
+  'BriefInfo': 0,
+  'OwnCoupon': 1,
+  'ExchangeCoupon': 2,
+});
+
 const Exchange = ({ setIsExchangeOpen }) => {
   const [token, setToken] = useState();
   const [user, setUser] = useContext(UserContext);
-  const [page, setPage] = useState(0);
-  const switchCoupon = () => setPage(1);
-  const switchExchange = () => setPage(2);
+  const [page, setPage] = useState(PointExchange.BriefInfo);
+  const switchCoupon = () => setPage(PointExchange.OwnCoupon);
+  const switchExchange = () => setPage(PointExchange.ExchangeCoupon);
   const handleCancel = () => setIsExchangeOpen(false);
 
   useEffect(() => {
@@ -319,7 +330,7 @@ const Exchange = ({ setIsExchangeOpen }) => {
 
   return (
     <Container>
-      {page === 0 ?
+      {page === PointExchange.BriefInfo ?
         <>
           <Title>{langText("COUPON_POINTS_EXCH")}</Title>
           <Description>
@@ -333,8 +344,8 @@ const Exchange = ({ setIsExchangeOpen }) => {
           </Button>
           <Cancel onClick={handleCancel}>{langText("BACK")}</Cancel>
         </> : null}
-      {page === 1 ? <CouponPage points={user.points} setPage={setPage} /> : null}
-      {page === 2 ? <ExchangePage points={user.points} setPage={setPage} /> : null}
+      {page === PointExchange.OwnCoupon ? <CouponPage points={user.points} setPage={setPage} /> : null}
+      {page === PointExchange.ExchangeCoupon ? <ExchangePage points={user.points} setPage={setPage} /> : null}
     </Container>
   )
 }

--- a/web/src/components/Redeem/index.js
+++ b/web/src/components/Redeem/index.js
@@ -178,8 +178,13 @@ const RedeemRow = ({ points, isUsed, code, setDisplayCode }) => {
   )
 }
 
+const RedeemSteps = Object.freeze({
+  'Listing': 0,
+  'ShowingCode': 1,
+});
+
 const Redeem = ({ setIsRedeemOpen }) => {
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState(RedeemSteps.Listing);
   const [redeems, setRedeems] = useState([]);
   const [displayCode, setDisplayCode] = useState(null);
   useEffect(() => {
@@ -199,19 +204,19 @@ const Redeem = ({ setIsRedeemOpen }) => {
 
   useEffect(() => {
     if (displayCode !== null) {
-      setStep(1);
+      setStep(RedeemSteps.ShowingCode);
     }
   }, [displayCode]);
 
   const handleCancel = () => setIsRedeemOpen(false);
   const handleFinish = () => {
-    setStep(0);
+    setStep(RedeemSteps.Listing);
     setDisplayCode(null);
   }
 
   return (
     <Container>
-      {step === 0 ?
+      {step === RedeemSteps.Listing ?
         <Content>
           <Title>{langText("REDEEM_LIST_TITLE")}</Title>
           <Description>{langText("REDEEM_COUNTER").replace("{number}", redeems.filter((r) => {
@@ -234,7 +239,7 @@ const Redeem = ({ setIsRedeemOpen }) => {
           </TableWrapper>
           <Cancel onClick={handleCancel}>{langText("BACK")}</Cancel>
         </Content> : null}
-      {step === 1 ?
+      {step === RedeemSteps.ShowingCode ?
         <Content>
           <Title>{langText('REDEEM_TARGET')}</Title>
           <QRCode value={displayCode} />

--- a/web/src/components/Trade/index.js
+++ b/web/src/components/Trade/index.js
@@ -96,11 +96,17 @@ const Content = styled.div`
   }
 `;
 
+const SendingSteps = Object.freeze({
+  'Scan': 0,
+  'Sending': 1,
+  'Success': 2,
+});
+
 const SendPage = ({setPage}) => {
   const [user, setUser] = useContext(UserContext);
   const [sendPoint, setSendPoint] = useState(0);
   const [isFixedAmount, setIsFixedAmount] = useState(false);
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState(SendingSteps.Scan);
   const [receiver, setReceiver] = useState('null');
   const handleScan = (stringData) => {
     if (stringData === null) return;
@@ -111,7 +117,7 @@ const SendPage = ({setPage}) => {
       setSendPoint(amount);
       setIsFixedAmount(true);
     }
-    setStep(1);
+    setStep(SendingSteps.Sending);
   };
   const handleError = (error) => {
     console.error({error});
@@ -130,7 +136,7 @@ const SendPage = ({setPage}) => {
       .then((resp) => {
         const { success } = resp.data;
         if (success) {
-          setStep(2);
+          setStep(SendingSteps.Success);
           user.points = (user.points - sendPoint);
           setUser(user);
         }
@@ -140,15 +146,15 @@ const SendPage = ({setPage}) => {
         console.error('transactions error: ', message);
       })
   }
-  const handleCancel = () => setPage(0);
+  const handleCancel = () => setPage(TradingPages.Init);
   const handleBackToScan = () => {
     setIsFixedAmount(false);
     setSendPoint(0);
-    setStep(0);
+    setStep(SendingSteps.Scan);
   }
   return(
   <Content>
-    { step === 0 ?
+    { step === SendingSteps.Scan ?
       <>
         <Title>{langText("TRADE_SEND_POINTS")}</Title>
         <Description>{langText("TRADE_SCAN_QR")}</Description>
@@ -159,7 +165,7 @@ const SendPage = ({setPage}) => {
         />
         <Cancel onClick={handleCancel}>{langText("CANCEL")}</Cancel>
      </> : "" }
-    { step === 1 ?
+    { step === SendingSteps.Sending ?
       <>
         <Title>{langText("TRADE_SEND_POINTS")}</Title>
         <div>{langText("TRADE_SENDING_QTY").replace("{points}", user.points)}</div>
@@ -171,7 +177,7 @@ const SendPage = ({setPage}) => {
         <Button onClick={handleSend}>{langText("CONFIRM")}</Button>
         <Cancel onClick={handleBackToScan}>{langText("CANCEL")}</Cancel>
       </> : "" }
-    { step === 2 ?
+    { step === SendingSteps.Success ?
       <>
        <Title>{langText("TRADE_SENT_SUCESS")}</Title>
        <Description>{langText("TRADE_SENT_DESC").replace("{sendPoint}", sendPoint).replace("{uid}", receiver)}</Description>
@@ -183,7 +189,7 @@ const SendPage = ({setPage}) => {
 }
 
 const ReceivedPage = ({uid, setPage}) => {
-  const handleCancel = () => setPage(0)
+  const handleCancel = () => setPage(TradingPages.Init)
   return(
     <Content>
       <Title>{langText("TRADE_RECEIVING")}</Title>
@@ -198,9 +204,14 @@ ReceivedPage.defaultProps = {
   uid: 'unknown',
 }
 
+const TakingSteps = Object.freeze({
+  'Scan': 0,
+  'Success': 1,
+});
+
 const TakePage = ({setPage}) => {
   const [user, setUser] = useContext(UserContext);
-  const [step, setStep] = useState(0);
+  const [step, setStep] = useState(TakingSteps.Scan);
   const [points, setPoints] = useState();
   const handleScan = (data) => {
     if (data === null) return;
@@ -214,7 +225,7 @@ const TakePage = ({setPage}) => {
           setPoints(points);
           user.points = user.points + points;
           setUser(user);
-          setStep(1);
+          setStep(TakingSteps.Success);
         }
       })
       .catch((error) => {
@@ -226,10 +237,10 @@ const TakePage = ({setPage}) => {
     console.error('take point scan error',err);
   }
 
-  const handleCancel = () => setPage(0)
+  const handleCancel = () => setPage(TradingPages.Init)
   return(
     <Content>
-      { step === 0 ?
+      { step === TakingSteps.Scan ?
       <>
         <Title>{langText("TRADE_REDEEM_POINTS")}</Title>
         <Description>{langText("TRADE_REDEEM_QR")}</Description>
@@ -240,7 +251,7 @@ const TakePage = ({setPage}) => {
         />
         <Cancel onClick={handleCancel}>{langText("CANCEL")}</Cancel>
       </> : "" }
-      { step === 1 ?
+      { step === TakingSteps.Success ?
       <>
         <Title>{langText("TRADE_REDEEM_CONFIRM")}</Title>
         <Description>{langText("TRADE_REDEEM_DONE").replace("{points}", points)}</Description>
@@ -252,13 +263,20 @@ const TakePage = ({setPage}) => {
 
 const TradingMain = styled.div``;
 
+const TradingPages = Object.freeze({
+  'Init': 0,
+  'Send': 1,
+  'Received': 2,
+  'Take': 3
+});
+
 const Trading = ({setIsTradningOpen}) => {
   const [user, setUser] = useContext(UserContext);
   const [uid, setUid] = useState();
-  const [page, setPage] = useState(0);
-  const switchSend = () => setPage(1);
-  const switchRecivied = () => setPage(2);
-  const switchTake = () => setPage(3);
+  const [page, setPage] = useState(TradingPages.Init);
+  const switchSend = () => setPage(TradingPages.Send);
+  const switchRecivied = () => setPage(TradingPages.Received);
+  const switchTake = () => setPage(TradingPages.Take);
   const handleCancel = () => setIsTradningOpen(false);
 
   useEffect(() => {
@@ -280,7 +298,7 @@ const Trading = ({setIsTradningOpen}) => {
 
   return (
     <TradingContainer>
-      { page === 0 ?
+      { page === TradingPages.Init ?
       <TradingMain>
         <Title>{langText("TRADE_TRADING_POINTS")}</Title>
         <Description>{langText("POINTS_OWNED").replace("{points}", user.points)}</Description>
@@ -298,9 +316,9 @@ const Trading = ({setIsTradningOpen}) => {
         </Button>
         <Cancel onClick={handleCancel}>{langText("CANCEL")}</Cancel>
       </TradingMain> : null }
-      { page === 1 ? <SendPage setPage={setPage}/> : null }
-      { page === 2 ? <ReceivedPage setPage={setPage} uid={uid}/> : null }
-      { page === 3 ? <TakePage setPage={setPage}/> : null }
+      { page === TradingPages.Send ? <SendPage setPage={setPage}/> : null }
+      { page === TradingPages.Received ? <ReceivedPage setPage={setPage} uid={uid}/> : null }
+      { page === TradingPages.Take ? <TakePage setPage={setPage}/> : null }
     </TradingContainer>
   );
 }


### PR DESCRIPTION
Current we use `step`/`page` equals to some integers to control the page state, but it's not friendly for developer to remember each of the integer meaning. 
Instead of using integers, I changed to use `Object.freeze` to list out the states/pages.  
It will also be easier to identify `setPage(0)` and `setStep(0)`.