### PR TITLE
Adjust Trade/Exchange/Redeem Modal breakpoint to 768px (tablets)

### DIFF
--- a/web/src/components/Exchange/index.js
+++ b/web/src/components/Exchange/index.js
@@ -1,7 +1,6 @@
 import axios from "axios";
 import React, { useEffect, useState, useContext } from "react";
 import styled from "styled-components";
-import QRCode from "react-qr-code";
 import Cookies from "js-cookie";
 import Modal from "../Modal";
 import { langText } from "../../lang";
@@ -10,7 +9,7 @@ import UserContext from '../../UserContext.js';
 import { toast } from 'react-toastify';
 
 const Container = styled(Modal)`
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     flex-direction: row;
     align-items: flex-start;
   }
@@ -21,13 +20,13 @@ const Title = styled.div`
   font-weight: bold;
   text-align: center;
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     padding-left: 30px;
   }
 `;
 
 const Description = styled.h3`
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     padding-left: 30px;
   }
 `;
@@ -53,7 +52,7 @@ const Button = styled.button`
     background: #858383;
   }
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     background: none;
     border-radius: 0;
     min-width: 249px;
@@ -74,7 +73,7 @@ const Cancel = styled(Button)`
 `;
 
 const Content = styled.div`
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     display: block;
     height: 100%;
     padding-left: 3em;

--- a/web/src/components/Modal/index.js
+++ b/web/src/components/Modal/index.js
@@ -16,11 +16,11 @@ const Modal = styled.div`
   padding: 46px 65px 0 65px;
   color: #121212;
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     min-height: 623px;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
+    left: 30%;
+    top: 30%;
+    transform: translate(-25%, -25%);
     border-radius: 43px;
     padding: 2em 0;
   }

--- a/web/src/components/Redeem/index.js
+++ b/web/src/components/Redeem/index.js
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import QRCode from "react-qr-code";
 import Cookies from "js-cookie";
-import TableScrollbar from 'react-table-scrollbar';
 import Modal from "../Modal";
 import { langText } from "../../lang";
 
@@ -11,7 +10,7 @@ import QRcodeImg from "../../public/qrcode.svg";
 
 const Container = styled(Modal)`
   padding: 20px 15px 15px 20px;
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     flex-direction: row;
     align-items: flex-start;
   }
@@ -22,13 +21,13 @@ const Title = styled.div`
   font-weight: bold;
   text-align: center;
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     padding-left: 30px;
   }
 `;
 
 const Description = styled.h3`
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     padding-left: 30px;
   }
 `;
@@ -54,7 +53,7 @@ const Button = styled.button`
     background: #858383;
   }
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     background: none;
     border-radius: 0;
     min-width: 249px;
@@ -79,7 +78,7 @@ const Content = styled.div`
   flex-direction: column;
   align-items: center;
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     display: block;
     height: 100%;
     padding-left: 3em;
@@ -99,7 +98,7 @@ const TableWrapper = styled.div`
   max-height: 60vh;
   overflow: auto;
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     max-height: 35vh;
   }
 `;

--- a/web/src/components/Trade/index.js
+++ b/web/src/components/Trade/index.js
@@ -14,7 +14,7 @@ import { langText } from "../../lang";
 import UserContext from '../../UserContext.js';
 
 const TradingContainer = styled(Modal)`
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     flex-direction: row;
     align-items: flex-start;
   }
@@ -25,7 +25,7 @@ const Title = styled.div`
   font-size: 36px;
   font-weight: bold;
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     padding-left: 30px;
   }
 `;
@@ -34,7 +34,7 @@ const Description = styled.h3`
   font-size: 20px;
   margin-bottom: 48px;
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     padding-left: 30px;
   }
 `;
@@ -60,7 +60,7 @@ const Button = styled.button`
     background: #858383;
   }
 
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     background: none;
     border-radius: 0;
     min-width: 249px;
@@ -81,7 +81,7 @@ const Cancel = styled(Button)`
 `;
 
 const Content = styled.div`
-  @media(min-width: 1280px) {
+  @media(min-width: 768px) {
     display: block;
     height: 100%;
     padding-left: 3em;


### PR DESCRIPTION
I'm working on redemption modal layout, and I would like to adjust Trade/Exchange/Redeem modals' breakpoint to `768px` (reference to [Bootstrap breakpoint](https://getbootstrap.com/docs/5.0/layout/breakpoints/))
Because we don't have many items need to display in modal, I think we could use general modal to display on tablets, instead of the mobile layout.
Although there is an issue is: it will also display general modal on some landscape mobile devices, but I think we could see how to handle it later?

Would like to make sure if you have any concern, or advice of breakpoint size?
@gcobcqwe @chuanchan1116 @canyugs 

![截圖 2021-11-21 下午4 15 20](https://user-images.githubusercontent.com/6468997/142754789-53d4d431-8e1a-4b74-af5b-62af40219b85.png)
