### PR TITLE
Adjust redemption RWD layout with flex box

### DIFF
--- a/web/src/components/CloseButton.js
+++ b/web/src/components/CloseButton.js
@@ -1,0 +1,43 @@
+import React from "react";
+import styled from "styled-components";
+
+const Container = styled.div`
+    display: none;
+    position: absolute;
+    top: 50px;
+    right: 50px;
+    width: 32px;
+    height: 32px;
+    border-radius: 16px;
+    opacity: 1;
+    background-color: #333;
+
+    :hover {
+        opacity: 0.3;
+        cursor: pointer;
+    }
+    :before, :after {
+        position: absolute;
+        top: 5.5px;
+        left: 14px;
+        content: ' ';
+        height: 20px;
+        width: 3px;
+        background-color: #fff;
+    }
+    :before {
+        transform: rotate(45deg);
+    }
+    :after {
+        transform: rotate(-45deg);
+    }
+    @media(min-width: 768px) {
+        display: block;
+    }
+`;
+
+const CloseButton = ({onClick}) => {
+  return <Container onClick={onClick} />;
+}
+
+export default CloseButton;

--- a/web/src/components/Redeem/index.js
+++ b/web/src/components/Redeem/index.js
@@ -3,6 +3,8 @@ import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import QRCode from "react-qr-code";
 import Cookies from "js-cookie";
+
+import CloseButton from "../CloseButton";
 import Modal from "../Modal";
 import { langText } from "../../lang";
 
@@ -13,6 +15,7 @@ const Container = styled(Modal)`
   @media(min-width: 768px) {
     flex-direction: row;
     align-items: flex-start;
+    padding: 65px 50px;
   }
 `;
 
@@ -20,16 +23,10 @@ const Title = styled.div`
   font-size: 36px;
   font-weight: bold;
   text-align: center;
-
-  @media(min-width: 768px) {
-    padding-left: 30px;
-  }
 `;
 
 const Description = styled.h3`
-  @media(min-width: 768px) {
-    padding-left: 30px;
-  }
+  color: #4B4B4B;
 `;
 
 const Button = styled.button`
@@ -67,6 +64,10 @@ const Button = styled.button`
 `
 
 const Cancel = styled(Button)`
+  display: flex;
+  @media(min-width: 768px) {
+    display: none;
+  }
   background: none;
   color: #8D8D8D;
   padding-left: 10px;
@@ -81,11 +82,10 @@ const Content = styled.div`
   @media(min-width: 768px) {
     display: block;
     height: 100%;
-    padding-left: 3em;
-    border-left: 2px solid #000;
 
     ${Title} {
       font-size: 28px;
+      text-align: left;
     }
 
     ${Description} {
@@ -224,6 +224,7 @@ const Redeem = ({ setIsRedeemOpen }) => {
 
   return (
     <Container>
+      <CloseButton onClick={handleCancel}/>
       {step === RedeemSteps.Listing &&
         <Content>
           <Title>{langText("REDEEM_LIST_TITLE")}</Title>

--- a/web/src/components/Redeem/index.js
+++ b/web/src/components/Redeem/index.js
@@ -53,6 +53,20 @@ const Button = styled.button`
   }
 `
 
+const CompleteButton = styled(Button)`
+  height: auto;
+  min-width: unset;
+  padding: 5px 40px;
+  border-radius: 22px;
+  width: auto;
+  background: #154ED6;
+  color: #fff;
+
+  :active {
+    background: rgba(21, 78, 214, 0.15);
+  }
+`;
+
 const Cancel = styled(Button)`
   display: flex;
   @media(min-width: 768px) {
@@ -95,6 +109,21 @@ const Content = styled.div`
       font-size: 20px;
     }
   }
+`;
+
+const QRCodeContent = styled(Content)`
+  @media(min-width: 768px) {
+    display: flex;
+    height: 100%;
+    align-items: center;
+    width: 100%;
+
+    ${Title} {
+      font-size: 28px;
+      text-align: center;
+    }
+  }
+}
 `;
 
 const SideBarItem = styled.div`
@@ -231,6 +260,11 @@ const Row = styled.div`
   }
 `;
 
+const QRCodeWrapper = styled.div`
+  margin: 65px 0;
+  text-align: center;
+`;
+
 const RedeemRow = ({ points, isUsed, code, setDisplayCode }) => {
   const handleShow = () => setDisplayCode(JSON.stringify({ code }));
   return (
@@ -285,36 +319,40 @@ const Redeem = ({ setIsRedeemOpen }) => {
 
   return (
     <Container>
-      <CloseButton onClick={handleCancel}/>
       <SideBar>
         <Title>{langText("REDEEM_LIST_TITLE")}</Title>
         <SideBarItem className="selected">{langText("REDEEM_LIST_TITLE")}</SideBarItem>
       </SideBar>
       {step === RedeemSteps.Listing &&
-        <Content>
-          <Title>{langText("REDEEM_LIST_TITLE")}</Title>
-          <Description>{langText("REDEEM_COUNTER").replace("{number}", redeems.filter((r) => {
-            return r.is_used === false;
-          }).length)}
-          </Description>
-          <TableWrapper>
-            <Column>
-              <Row className="columnHeader">
-                <div>{langText("REDEEM_VALUE")}</div>
-                <div>{langText("REDEEM_STATE")}</div>
-                <div>{langText("REDEEM_CODE")}</div>
-              </Row>
-              {redeems.map((r, idx) => <RedeemRow key={idx} isUsed={r.is_used} code={r.code} points={r.points} setDisplayCode={setDisplayCode} />)}
-            </Column>
-          </TableWrapper>
-          <Cancel onClick={handleCancel}>{langText("BACK")}</Cancel>
-        </Content>}
+        <>
+          <CloseButton onClick={handleCancel}/>
+          <Content>
+            <Title>{langText("REDEEM_LIST_TITLE")}</Title>
+            <Description>{langText("REDEEM_COUNTER").replace("{number}", redeems.filter((r) => {
+              return r.is_used === false;
+            }).length)}
+            </Description>
+            <TableWrapper>
+              <Column>
+                <Row className="columnHeader">
+                  <div>{langText("REDEEM_VALUE")}</div>
+                  <div>{langText("REDEEM_STATE")}</div>
+                  <div>{langText("REDEEM_CODE")}</div>
+                </Row>
+                {redeems.map((r, idx) => <RedeemRow key={idx} isUsed={r.is_used} code={r.code} points={r.points} setDisplayCode={setDisplayCode} />)}
+              </Column>
+            </TableWrapper>
+            <Cancel onClick={handleCancel}>{langText("BACK")}</Cancel>
+          </Content>
+        </>}
       {step === RedeemSteps.ShowingCode &&
-        <Content>
+        <QRCodeContent>
           <Title>{langText('REDEEM_TARGET')}</Title>
-          <QRCode value={displayCode} />
-          <Button onClick={handleFinish}>{langText("DONE")}</Button>
-        </Content>}
+          <QRCodeWrapper>
+            <QRCode value={displayCode}/>
+          </QRCodeWrapper>
+          <CompleteButton onClick={handleFinish}>{langText("DONE")}</CompleteButton>
+        </QRCodeContent>}
     </Container>
   )
 }

--- a/web/src/components/Redeem/index.js
+++ b/web/src/components/Redeem/index.js
@@ -106,8 +106,16 @@ const TableWrapper = styled.div`
 const Table = styled.table`
   position: relative;
 
+  .statusText {
+    color: #729b55;
+  }
+
   .isUsed {
-    background: #6b6b6b
+    background: #D0D0D0;
+
+    .statusText {
+      color: #b29d9c;
+    }
   }
 
   th, td {
@@ -167,7 +175,7 @@ const RedeemRow = ({ points, isUsed, code, setDisplayCode }) => {
   return (
     <tr className={isUsed ? "isUsed" : "notUsed"}>
       <td>{points}</td>
-      <td>{isUsed ? langText("REDEEM_STATE_SENT") : langText("REDEEM_STATE_AVAIABLE")}</td>
+      <td className="statusText">{isUsed ? langText("REDEEM_STATE_SENT") : langText("REDEEM_STATE_AVAIABLE")}</td>
       <td>
         {code}
         <button onClick={handleShow}>
@@ -216,7 +224,7 @@ const Redeem = ({ setIsRedeemOpen }) => {
 
   return (
     <Container>
-      {step === RedeemSteps.Listing ?
+      {step === RedeemSteps.Listing &&
         <Content>
           <Title>{langText("REDEEM_LIST_TITLE")}</Title>
           <Description>{langText("REDEEM_COUNTER").replace("{number}", redeems.filter((r) => {
@@ -238,13 +246,13 @@ const Redeem = ({ setIsRedeemOpen }) => {
           </Table>
           </TableWrapper>
           <Cancel onClick={handleCancel}>{langText("BACK")}</Cancel>
-        </Content> : null}
-      {step === RedeemSteps.ShowingCode ?
+        </Content>}
+      {step === RedeemSteps.ShowingCode &&
         <Content>
           <Title>{langText('REDEEM_TARGET')}</Title>
           <QRCode value={displayCode} />
           <Button onClick={handleFinish}>{langText("DONE")}</Button>
-        </Content> : null}
+        </Content>}
     </Container>
   )
 }

--- a/web/src/components/Redeem/index.js
+++ b/web/src/components/Redeem/index.js
@@ -9,24 +9,14 @@ import Modal from "../Modal";
 import { langText } from "../../lang";
 
 import QRCodeImg from "../../public/qrcode.svg";
+import UsedQRCodeImg from "../../public/usedQrcode.svg";
 
 const Container = styled(Modal)`
-  padding: 20px 15px 15px 20px;
   @media(min-width: 768px) {
     flex-direction: row;
     align-items: flex-start;
     padding: 65px 50px;
   }
-`;
-
-const Title = styled.div`
-  font-size: 36px;
-  font-weight: bold;
-  text-align: center;
-`;
-
-const Description = styled.h3`
-  color: #4B4B4B;
 `;
 
 const Button = styled.button`
@@ -72,6 +62,17 @@ const Cancel = styled(Button)`
   color: #8D8D8D;
   padding-left: 10px;
   font-size: 24px;
+  margin-top: 20px;
+`;
+
+const Title = styled.div`
+  font-size: 36px;
+  font-weight: bold;
+  text-align: center;
+`;
+
+const Description = styled.h3`
+  color: #4B4B4B;
 `;
 
 const Content = styled.div`
@@ -82,6 +83,8 @@ const Content = styled.div`
   @media(min-width: 768px) {
     display: block;
     height: 100%;
+    align-items: left;
+    max-width: 100%;
 
     ${Title} {
       font-size: 28px;
@@ -94,95 +97,153 @@ const Content = styled.div`
   }
 `;
 
+const SideBarItem = styled.div`
+  font-size: 20px;
+  padding: 20px 40px 20px 50px;
+  margin-left: -50px;
+  font-weight: bold;
+
+  &.selected {
+    color: #002680;
+    background-color: #D9DEEB;
+  }
+`;
+
+const SideBar = styled.div`
+  display: none;
+  flex-direction: column;
+  border-right: 2px solid #000;
+  height: 100%;
+  min-width: 245px;
+
+  ${Title} {
+    text-align: left;
+    font-size: 36px;
+    margin-top: 5px;
+    margin-bottom: 50px;
+  }
+
+  @media(min-width: 1280px) {
+    display: flex;
+    margin-right: 40px;
+  }
+`;
+
 const TableWrapper = styled.div`
   max-height: 60vh;
   overflow: auto;
 
   @media(min-width: 768px) {
-    max-height: 35vh;
+    max-height: 40vh;
   }
 `;
 
-const Table = styled.table`
-  position: relative;
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  .columnHeader > div, .columnHeader > div:nth-child(3) {
+    z-index: 1;
+    color: #fff;
+    background: #002680;
+    padding: 15px 10px;
+    font-family: inherit;
+    text-align: center;
+  }
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
 
   .statusText {
     color: #729b55;
   }
 
-  .isUsed {
-    background: #D0D0D0;
+  &.isUsed {
+    div {
+      background: #D0D0D0;
+    }
 
     .statusText {
       color: #b29d9c;
     }
   }
 
-  th, td {
+  div {
     padding: 15px 10px;
     box-sizing: border-box;
-  }
-
-  th {
-    padding: 10px;
-    z-index: 1;
-    background: #002680;
-    color: #fff;
-    position: sticky;
-    top: 0;
-  }
-
-  tr {
     background: #EDEDED;
+    margin: 1px;
+  }
 
-    td:nth-child(1) {
-      min-width: 85px;
-      text-align: center;
-    }
-    td:nth-child(2) {
-      min-width: 100px;
-    }
-    td:nth-child(3) {
-      position: relative;
-      max-width: 162px;
+  div:nth-child(1) {
+    min-width: 85px;
+    text-align: center;
+    border-top-left-radius: 5px;
+    border-bottom-left-radius: 5px;
+  }
+  div:nth-child(2) {
+    min-width: 100px;
+    text-align: center;
+  }
+
+  div:nth-child(3) {
+    position: relative;
+    max-width: 420px;
+    padding: 15px 40px 15px 10px;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    flex: 1;
+    overflow: hidden;
+
+    div {
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-      padding: 15px 40px 15px 10px;
       font-family: monospace;
+      text-algin: center;
+      margin-right: 10px;
+      padding: 0;
+    }
 
+    button {
+      position: absolute;
+      top: 7px;
+      right: 0;
+      background: none;
 
-      button {
-        position: absolute;
-        top: 7px;
-        right: 0;
-        background: none;
-      }
+      :disabled {
+        cursor: initial;
 
-      img {
-        background: #fff;
-        border: 4px solid #fff;
-        border-radius: 5px;
-        box-shadow: 0px 2px 4px #101010d9;
+        img {
+          box-shadow: none;
+        }
       }
     }
+
+    img {
+      background: #fff;
+      border: 4px solid #fff;
+      border-radius: 5px;
+      box-shadow: 0px 2px 4px #101010d9;
+    }
+  }
 `;
-
-
 
 const RedeemRow = ({ points, isUsed, code, setDisplayCode }) => {
   const handleShow = () => setDisplayCode(JSON.stringify({ code }));
   return (
-    <tr className={isUsed ? "isUsed" : "notUsed"}>
-      <td>{points}</td>
-      <td className="statusText">{isUsed ? langText("REDEEM_STATE_SENT") : langText("REDEEM_STATE_AVAIABLE")}</td>
-      <td>
-        {code}
-        <button onClick={handleShow}>
-          <img src={QRCodeImg} />
+    <Row className={isUsed ? "isUsed" : "notUsed"}>
+      <div>{points}</div>
+      <div className="statusText">{isUsed ? langText("REDEEM_STATE_SENT") : langText("REDEEM_STATE_AVAIABLE")}</div>
+      <div>
+        <div>{code}</div>
+        <button onClick={handleShow} disabled={isUsed}>
+          <img src={isUsed ? UsedQRCodeImg : QRCodeImg} />
         </button>
-      </td>
-    </tr>
+      </div>
+    </Row>
   )
 }
 
@@ -225,6 +286,10 @@ const Redeem = ({ setIsRedeemOpen }) => {
   return (
     <Container>
       <CloseButton onClick={handleCancel}/>
+      <SideBar>
+        <Title>{langText("REDEEM_LIST_TITLE")}</Title>
+        <SideBarItem className="selected">{langText("REDEEM_LIST_TITLE")}</SideBarItem>
+      </SideBar>
       {step === RedeemSteps.Listing &&
         <Content>
           <Title>{langText("REDEEM_LIST_TITLE")}</Title>
@@ -233,18 +298,14 @@ const Redeem = ({ setIsRedeemOpen }) => {
           }).length)}
           </Description>
           <TableWrapper>
-          <Table>
-            <thead>
-              <tr>
-                <th>{langText("REDEEM_VALUE")}</th>
-                <th>{langText("REDEEM_STATE")}</th>
-                <th>{langText("REDEEM_CODE")}</th>
-              </tr>
-            </thead>
-            <tbody>
+            <Column>
+              <Row className="columnHeader">
+                <div>{langText("REDEEM_VALUE")}</div>
+                <div>{langText("REDEEM_STATE")}</div>
+                <div>{langText("REDEEM_CODE")}</div>
+              </Row>
               {redeems.map((r, idx) => <RedeemRow key={idx} isUsed={r.is_used} code={r.code} points={r.points} setDisplayCode={setDisplayCode} />)}
-            </tbody>
-          </Table>
+            </Column>
           </TableWrapper>
           <Cancel onClick={handleCancel}>{langText("BACK")}</Cancel>
         </Content>}

--- a/web/src/public/usedQrcode.svg
+++ b/web/src/public/usedQrcode.svg
@@ -1,0 +1,15 @@
+<svg id="Group_189" data-name="Group 189" xmlns="http://www.w3.org/2000/svg" width="23.473" height="23.473" viewBox="0 0 23.473 23.473">
+  <g id="Group_188" data-name="Group 188">
+    <path id="Path_139" data-name="Path 139" d="M3,13.239H13.239V3H3ZM5.56,5.56h5.12v5.12H5.56Z" transform="translate(-3 -3)" fill="#ededed"/>
+    <path id="Path_140" data-name="Path 140" d="M3,23.239H13.239V13H3ZM5.56,15.56h5.12v5.12H5.56Z" transform="translate(-3 -0.201)" fill="#ededed"/>
+    <path id="Path_141" data-name="Path 141" d="M13,3V13.239H23.239V3Zm7.679,7.679H15.56V5.56h5.12Z" transform="translate(-0.201 -3)" fill="#ededed"/>
+    <rect id="Rectangle_1324" data-name="Rectangle 1324" width="3.983" height="3.983" transform="translate(19.489 19.489)" fill="#ededed"/>
+    <rect id="Rectangle_1325" data-name="Rectangle 1325" width="1.992" height="1.992" transform="translate(13.514 13.514)" fill="#ededed"/>
+    <rect id="Rectangle_1326" data-name="Rectangle 1326" width="1.992" height="1.992" transform="translate(15.506 15.506)" fill="#ededed"/>
+    <rect id="Rectangle_1327" data-name="Rectangle 1327" width="1.992" height="1.992" transform="translate(13.514 17.498)" fill="#ededed"/>
+    <rect id="Rectangle_1328" data-name="Rectangle 1328" width="1.992" height="3.983" transform="translate(15.506 19.489)" fill="#ededed"/>
+    <rect id="Rectangle_1329" data-name="Rectangle 1329" width="1.992" height="1.992" transform="translate(17.498 17.498)" fill="#ededed"/>
+    <rect id="Rectangle_1330" data-name="Rectangle 1330" width="1.992" height="1.992" transform="translate(17.498 13.514)" fill="#ededed"/>
+    <rect id="Rectangle_1331" data-name="Rectangle 1331" width="3.983" height="1.992" transform="translate(19.489 15.506)" fill="#ededed"/>
+  </g>
+</svg>


### PR DESCRIPTION
I adjusted the layout of redemption page, I'm not familiar with table, so use flex box to instead. 
The sidebar is not able to fully display in tablet devices, so I hide sidebar between 768px ~ 1279px. 

window size >= 1280px:
<img width="1427" alt="截圖 2021-11-24 上午1 08 12" src="https://user-images.githubusercontent.com/6468997/143071208-0d3f4929-d21c-42a4-98c3-b7f6b893a511.png">
<img width="1427" alt="截圖 2021-11-24 上午1 08 16" src="https://user-images.githubusercontent.com/6468997/143071236-b1f3bf94-bdbf-4aee-ad29-e6870a1e3acc.png">
1280px > window size >= 768px
<img width="1216" alt="截圖 2021-11-24 上午1 08 26" src="https://user-images.githubusercontent.com/6468997/143071871-799468b8-648a-41bc-a83f-40bb6268400f.png">
<img width="1216" alt="截圖 2021-11-24 上午1 08 23" src="https://user-images.githubusercontent.com/6468997/143071909-3265abb7-9192-44f9-aa7b-7b00814ac0c0.png">
window size > 786px (mobile)
<img width="728" alt="截圖 2021-11-24 上午1 08 34" src="https://user-images.githubusercontent.com/6468997/143072002-2ee20822-0293-4e2f-8350-9321ea450d02.png">
<img width="728" alt="截圖 2021-11-24 上午1 08 37" src="https://user-images.githubusercontent.com/6468997/143072017-44a5d3ff-f218-43de-951c-8caf0a1fa15b.png">

