### PR TITLE
Adjust trade layout to put elements in center

### DIFF
--- a/web/src/components/Trade/index.js
+++ b/web/src/components/Trade/index.js
@@ -21,34 +21,27 @@ const TradingContainer = styled(Modal)`
 const Title = styled.div`
   font-size: 36px;
   font-weight: bold;
-
-  @media(min-width: 768px) {
-    padding-left: 30px;
-  }
 `;
 
 const Description = styled.h3`
   font-size: 20px;
   margin-bottom: 48px;
-
-  @media(min-width: 768px) {
-    padding-left: 30px;
-  }
 `;
 
-const Button = styled.button`
+const Button = styled.div`
+  display: flex;
+  justify-content: center;
   position: relative;
   background: #E5E5E5;
   border-radius: 13px;
-  width: 100%;
   height: 57px;
   border: none;
   box-shadow: none;
   margin-bottom: 34px;
   font-size: 24px;
-  display: flex;
-  justify-content: center;
   align-items: center;
+  padding: 10px 17px;
+  cursor: pointer;
   img {
     padding-right: 20px;
   }
@@ -56,13 +49,14 @@ const Button = styled.button`
   :active {
     background: #858383;
   }
+  :hover {
+    background: rgba(229, 229, 229, 0.35);
+  }
 
   @media(min-width: 768px) {
     background: none;
     border-radius: 0;
     min-width: 249px;
-    justify-content: left;
-    padding-left: 30px;
 
     :active {
       background: rgba(0, 38, 128, 0.15);
@@ -75,6 +69,7 @@ const Cancel = styled(Button)`
   color: #8D8D8D;
   padding-left: 10px;
   font-size: 24px;
+  margin-top: 30px;
 `;
 
 const Content = styled.div`


### PR DESCRIPTION
- Update <Button/> from `styled.button` to `styled.div`
- Remove the left padding of desktop layout and make the items align center. 


#### Screen Shots
- On minimum desktop screen size (about 769px) screen shots
    <img width="804" alt="截圖 2021-11-26 上午3 13 30" src="https://user-images.githubusercontent.com/6468997/143491903-54ebc146-9166-474a-bd68-22254473a09c.png">
    <img width="804" alt="截圖 2021-11-26 上午3 13 38" src="https://user-images.githubusercontent.com/6468997/143491917-9da4ea1e-a247-492f-bff6-f66c89975a0d.png">
    <img width="804" alt="截圖 2021-11-26 上午3 13 42" src="https://user-images.githubusercontent.com/6468997/143491924-b1e39fce-efa8-483d-a6a4-a317b4bd6f2b.png">
    <img width="804" alt="截圖 2021-11-26 上午3 13 45" src="https://user-images.githubusercontent.com/6468997/143491926-c598bf55-5653-4253-af23-bd4a5182d837.png">
- On iPhone 6/7/8/SE2 screen shots
    <img width="755" alt="截圖 2021-11-26 上午3 14 10" src="https://user-images.githubusercontent.com/6468997/143491927-8d868266-0127-4dcc-9311-c502be3a254a.png">
    <img width="755" alt="截圖 2021-11-26 上午3 14 14" src="https://user-images.githubusercontent.com/6468997/143491931-354f1bb8-d6c7-460b-acb6-5c6e30ff383f.png">
    <img width="755" alt="截圖 2021-11-26 上午3 14 19" src="https://user-images.githubusercontent.com/6468997/143491934-8ccf78ab-00de-476b-8a01-4fcdea9c9b6a.png">
    <img width="755" alt="截圖 2021-11-26 上午3 14 22" src="https://user-images.githubusercontent.com/6468997/143491936-415d6e7e-26c3-492d-b6d9-631968b67546.png">
